### PR TITLE
Only one filepath on package install

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -5,7 +5,7 @@
 set -e
 
 # Debug
-set -x
+# set -x
 
 # Parse and derive params
 BUILD_DIR=$1
@@ -38,6 +38,9 @@ apt-get $APT_OPTIONS -y --force-yes -d install --reinstall --no-install-recommen
 IFS=" " read -a DEP_PKGS <<< $DEPS
 for DEP in ${DEP_PKGS[@]}; do
   echo "Installing $DEP" | indent
+  # Sometimes multiple matching packages are found
+  # which blows up on the dpkg command
+  # so grabbing them this way only returns a single filepath
   package_paths_pattern="$APT_CACHE_DIR/archives/$DEP\_*.deb"
   package_paths=( $package_paths_pattern )
   dpkg -x $package_paths $APT_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -40,7 +40,7 @@ for DEP in ${DEP_PKGS[@]}; do
   echo "Installing $DEP" | indent
   package_paths_pattern="$APT_CACHE_DIR/archives/$DEP\_*.deb"
   package_paths=( $package_paths_pattern )
-  dpkg -x $package_paths[0] $APT_DIR
+  dpkg -x $package_paths $APT_DIR
 done
 
 # Install Datadog Agent

--- a/bin/compile
+++ b/bin/compile
@@ -40,7 +40,7 @@ for DEP in ${DEP_PKGS[@]}; do
   echo "Installing $DEP" | indent
   package_paths_pattern="$APT_CACHE_DIR/archives/$DEP\_*.deb"
   package_paths=( $package_paths_pattern )
-  dpkg -x package_paths[0] $APT_DIR
+  dpkg -x $package_paths[0] $APT_DIR
 done
 
 # Install Datadog Agent

--- a/bin/compile
+++ b/bin/compile
@@ -38,7 +38,9 @@ apt-get $APT_OPTIONS -y --force-yes -d install --reinstall --no-install-recommen
 IFS=" " read -a DEP_PKGS <<< $DEPS
 for DEP in ${DEP_PKGS[@]}; do
   echo "Installing $DEP" | indent
-  dpkg -x $APT_CACHE_DIR/archives/$DEP\_*.deb $APT_DIR
+  package_paths_pattern="$APT_CACHE_DIR/archives/$DEP\_*.deb"
+  package_paths=( $package_paths_pattern )
+  dpkg -x package_paths[0] $APT_DIR
 done
 
 # Install Datadog Agent

--- a/bin/compile
+++ b/bin/compile
@@ -38,6 +38,7 @@ apt-get $APT_OPTIONS -y --force-yes -d install --reinstall --no-install-recommen
 IFS=" " read -a DEP_PKGS <<< $DEPS
 for DEP in ${DEP_PKGS[@]}; do
   echo "Installing $DEP" | indent
+  echo $APT_DIR
   dpkg -x $APT_CACHE_DIR/archives/$DEP\_*.deb $APT_DIR
 done
 

--- a/bin/compile
+++ b/bin/compile
@@ -38,7 +38,10 @@ apt-get $APT_OPTIONS -y --force-yes -d install --reinstall --no-install-recommen
 IFS=" " read -a DEP_PKGS <<< $DEPS
 for DEP in ${DEP_PKGS[@]}; do
   echo "Installing $DEP" | indent
+  echo "APT_DIR"
   echo $APT_DIR
+  echo "APT_CACHE_DIR"
+  echo $APT_CACHE_DIR
   dpkg -x $APT_CACHE_DIR/archives/$DEP\_*.deb $APT_DIR
 done
 

--- a/bin/compile
+++ b/bin/compile
@@ -5,7 +5,7 @@
 set -e
 
 # Debug
-# set -x
+set -x
 
 # Parse and derive params
 BUILD_DIR=$1
@@ -38,11 +38,7 @@ apt-get $APT_OPTIONS -y --force-yes -d install --reinstall --no-install-recommen
 IFS=" " read -a DEP_PKGS <<< $DEPS
 for DEP in ${DEP_PKGS[@]}; do
   echo "Installing $DEP" | indent
-  echo "APT_DIR"
-  echo $APT_DIR
-  echo "APT_CACHE_DIR"
-  echo $APT_CACHE_DIR
-  dpkg -x $APT_CACHE_DIR/archives/$DEP.deb $APT_DIR
+  dpkg -x $APT_CACHE_DIR/archives/$DEP\_*.deb $APT_DIR
 done
 
 # Install Datadog Agent

--- a/bin/compile
+++ b/bin/compile
@@ -42,7 +42,7 @@ for DEP in ${DEP_PKGS[@]}; do
   echo $APT_DIR
   echo "APT_CACHE_DIR"
   echo $APT_CACHE_DIR
-  dpkg -x $APT_CACHE_DIR/archives/$DEP\_*.deb $APT_DIR
+  dpkg -x $APT_CACHE_DIR/archives/$DEP.deb $APT_DIR
 done
 
 # Install Datadog Agent


### PR DESCRIPTION
This change ensures only a package filepath is passed to `dpkg`